### PR TITLE
minimal unix support, display gerrit IDs in listing, some better execution hanlding, project don't require --project option

### DIFF
--- a/gerrit.py
+++ b/gerrit.py
@@ -138,7 +138,8 @@ if __name__ == '__main__':
     }
     parser = argparse.ArgumentParser()
     parser.add_argument('--project', help=help['project'])
-    parser.add_argument('positional_project', help=help['project'])
+    parser.add_argument('positional_project', nargs='?', default=None,
+                        help=help['project'])
     parser.add_argument('--action', help=help['action'], default='checkout')
     parser.add_argument('--gtscore',
                         help=help['gtscore'], default=-3, type=int)


### PR DESCRIPTION
Mostly minor stuff. supporting linux when running gnome in open action, display gerrit IDs as well in listing, using the env handler for easier python discovery (not everyone has python in /usr/bin/python unfortunately)
The option positional argument approach for project so that --project is not needed is probably going to confuse users but I felt that passing --project all the time was cumbersome. Maybe some autodetecting of project through git remote -v is also possible as well.
