### PR TITLE
Don't submit "None" as a comment

### DIFF
--- a/gerrit.py
+++ b/gerrit.py
@@ -271,7 +271,11 @@ def submit_review( score, message ):
     process = subprocess.Popen('git rev-parse HEAD', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     output, error = process.communicate()
     commit = output.strip()
-    msg = "'%s'"%message
+    if not message:
+    	msg = "''"
+    else:
+    	msg = "'%s'"%message
+
     subprocess.call(['ssh', '-p 29418',
         'gerrit.wikimedia.org', 'gerrit', 'review',
         '--code-review', score, '--message', msg, commit])


### PR DESCRIPTION
If no comment was used for submit_review, python will use "None" as a converted string, which adds a simple "None" to gerrit's submit comment. That could be misleading and/or confusing, so use an empty comment instead.
